### PR TITLE
BF: Prioritize subdataset clone configuration

### DIFF
--- a/.datalad/config
+++ b/.datalad/config
@@ -1,4 +1,4 @@
 [datalad "dataset"]
 	id = 2e2a8a70-3eaa-11ea-a9a5-b4969157768c
 [datalad "get"]
-	subdataset-source-candidate-origin = "ria+http://store.datalad.org#{id}"
+	subdataset-source-candidate-300origin = "ria+http://store.datalad.org#{id}"


### PR DESCRIPTION
This sets a costs to the previously unprioritized subdataset clone
candidate origin. Without a prioritization, a subdataset clone config
gets assigned the default cost of 700. This cost is higher than the cost
of remote URL + submodule path, and thus Github URLs get tried first.

As the 0.15 release brought URL substitutation for GitHub URLs, the
Github URLs that are built became suddenly usable/genuine-looking enough
that an attempt to clone them did not directly (silently) fail.
If a user with datalad version 0.15 an higher clones this dataset via
HTTPS, a clone of any subdataset would then start to prompt for GitHub
credentials.

This has been reported and analyzed in
https://github.com/datalad/datalad/issues/6080.